### PR TITLE
Add shields to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/margloG/super_admin?logo=GitHub)
+[![GitHub issues](https://img.shields.io/github/issues/margloG/super_admin)](https://github.com/margloG/super_admin/issues)
+[![GitHub license](https://img.shields.io/github/license/margloG/super_admin?logo=Unlicense)](https://github.com/margloG/super_admin)
+
 # Super Admin
 
 ## Install
-Create virtualenv for this project and activate it. 
+
+Create virtualenv for this project and activate it.
 
 Then clone the repo and install requirements.
 
@@ -12,9 +17,11 @@ pip install -r requirements.txt
 ```
 
 ### local_settings.py
+
 Create this file beside settings.py file (under super_admin directory)
 
 With the following content:
+
 ```python
 DEBUG = True
 ```
@@ -23,8 +30,8 @@ That's it.
 
 Now you could start the server and access the site [admin](http://127.0.0.1:8000/admin/) panel.
 
-
 ## Additional materials
-* [bootstrap](https://getbootstrap.com/)
-* [django-bootstrap5](https://django-bootstrap5.readthedocs.io/en/latest/index.html)
-* [bootstrap icons](https://icons.getbootstrap.com/) - click on icon to see how to use it
+
+- [bootstrap](https://getbootstrap.com/)
+- [django-bootstrap5](https://django-bootstrap5.readthedocs.io/en/latest/index.html)
+- [bootstrap icons](https://icons.getbootstrap.com/) - click on icon to see how to use it


### PR DESCRIPTION
Added only three lines at the beginning of the document with shields/badges from [shields.io](https://shields.io/).
Nothing has been removed, just moved a little.

Wanted to add more, with versions, but something went wrong → ![GitHub Pipenv locked Python version](https://img.shields.io/github/pipenv/locked/python-version/margloG/super_admin)  You don't really have a _Pipfile.lock_ — I don't know what this file is and why it doesn't exist.